### PR TITLE
Delete allowBackup=true in library's AndroidManifest

### DIFF
--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -1,10 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="com.wang.avi">
 
-    <application android:allowBackup="true"
-                 android:label="@string/app_name"
-        >
-
+    <application android:label="@string/app_name">
     </application>
 
 </manifest>


### PR DESCRIPTION
@81813780 Hi, AVLoadingIndicatorView is a great library. I want to use this in my app. When I add dependencies in build.gradle, following error occurred.

```
Error:Execution failed for task ':app:processDevelopmentDebugManifest'.
> Manifest merger failed : Attribute application@allowBackup value=(false) from AndroidManifest.xml:29:9-36
  	is also present at [com.wang.avi:library:1.0.1] AndroidManifest.xml:12:9-35 value=(true).
  	Suggestion: add 'tools:replace="android:allowBackup"' to <application> element at AndroidManifest.xml:27:5-102:19 to override.
```

The cause of this error is `allowBackup=true` in library's AndroidManifest. I think any library should't use allowBackup attribute, because it's attribute for client app.