### PR TITLE
Fix typo: IOS -> iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ AVLoadingIndicatorView
 ## Introduction
 AVLoadingIndicatorView is a collection of nice loading animations for Android.
 
-You can also find IOS version of this [here](https://github.com/ninjaprox/NVActivityIndicatorView).
+You can also find iOS version of this [here](https://github.com/ninjaprox/NVActivityIndicatorView).
 
 ## Demo
 ![](https://github.com/81813780/AVLoadingIndicatorView/blob/master/Demo2.gif)


### PR DESCRIPTION
@81813780 I found typo in README and fixed it.
`IOS -> iOS`