### PR TITLE
Fix bug: the animator is not started when the AVLoadingIndicatorView added to a layout the second time.

### DIFF
--- a/library/src/main/java/com/wang/avi/AVLoadingIndicatorView.java
+++ b/library/src/main/java/com/wang/avi/AVLoadingIndicatorView.java
@@ -328,11 +328,18 @@ public class AVLoadingIndicatorView extends View{
     }
 
     @Override
+	protected void onAttachedToWindow() {
+		super.onAttachedToWindow();
+		if (mHasAnimation) {
+			mIndicatorController.setAnimationStatus(BaseIndicatorController.AnimStatus.START);
+		}
+	}
+	
+    @Override
     protected void onDetachedFromWindow() {
         super.onDetachedFromWindow();
         mIndicatorController.setAnimationStatus(BaseIndicatorController.AnimStatus.CANCEL);
     }
-
 
     void drawIndicator(Canvas canvas){
         mIndicatorController.draw(canvas,mPaint);
@@ -345,6 +352,4 @@ public class AVLoadingIndicatorView extends View{
     private int dp2px(int dpValue) {
         return (int) getContext().getResources().getDisplayMetrics().density * dpValue;
     }
-
-
 }

--- a/library/src/main/java/com/wang/avi/AVLoadingIndicatorView.java
+++ b/library/src/main/java/com/wang/avi/AVLoadingIndicatorView.java
@@ -328,13 +328,13 @@ public class AVLoadingIndicatorView extends View{
     }
 
     @Override
-	protected void onAttachedToWindow() {
-		super.onAttachedToWindow();
-		if (mHasAnimation) {
-			mIndicatorController.setAnimationStatus(BaseIndicatorController.AnimStatus.START);
-		}
-	}
-	
+    protected void onAttachedToWindow() {
+        super.onAttachedToWindow();
+        if (mHasAnimation) {
+            mIndicatorController.setAnimationStatus(BaseIndicatorController.AnimStatus.START);
+        }
+    }
+
     @Override
     protected void onDetachedFromWindow() {
         super.onDetachedFromWindow();


### PR DESCRIPTION
The first time an AVLoadingIndicatorView added into a layout, the animator runs as expected. But if you remove the AVLoadingIndicatorView from the layout, and after some time, add the same AVLoadingIndicatorView to the layout again, the animator is not started.