### PR TITLE
优化 onDraw 方法，降低内存占用以及 GC 频率

### DIFF
--- a/library/src/main/java/com/wang/avi/indicators/BallSpinFadeLoaderIndicator.java
+++ b/library/src/main/java/com/wang/avi/indicators/BallSpinFadeLoaderIndicator.java
@@ -41,8 +41,12 @@ public class BallSpinFadeLoaderIndicator extends Indicator {
         float radius=getWidth()/10;
         for (int i = 0; i < 8; i++) {
             canvas.save();
-            Point point=circleAt(getWidth(),getHeight(),getWidth()/2-radius,i*(Math.PI/4));
-            canvas.translate(point.x,point.y);
+            double angle = i * (Math.PI / 4);
+            float realRadius = getWidth()/2-radius;
+            float x = (float) (getWidth()/2 + realRadius * (Math.cos(angle)));
+            float y = (float) (getHeight()/2 + realRadius * (Math.sin(angle)));
+
+            canvas.translate(x, y);
             canvas.scale(scaleFloats[i],scaleFloats[i]);
             paint.setAlpha(alphas[i]);
             canvas.drawCircle(0,0,radius,paint);


### PR DESCRIPTION
由于 onDraw 方法会被大量频繁的调用，原来的实现中。 Point 对象会被大量的创建，这样会导致内存不断分配并触发 GC，现在去掉 point 对象的动态创建。