### PR TITLE
FIX 55

### DIFF
--- a/library/src/main/java/com/wang/avi/AVLoadingIndicatorView.java
+++ b/library/src/main/java/com/wang/avi/AVLoadingIndicatorView.java
@@ -207,7 +207,6 @@ public class AVLoadingIndicatorView extends View {
             // shown long enough.
             if (!mPostedHide) {
                 postDelayed(mDelayedHide, MIN_SHOW_TIME - diff);
-                mPostedShow = false;
                 mPostedHide = true;
             }
         }

--- a/library/src/main/java/com/wang/avi/AVLoadingIndicatorView.java
+++ b/library/src/main/java/com/wang/avi/AVLoadingIndicatorView.java
@@ -207,6 +207,7 @@ public class AVLoadingIndicatorView extends View {
             // shown long enough.
             if (!mPostedHide) {
                 postDelayed(mDelayedHide, MIN_SHOW_TIME - diff);
+                mPostedShow = false;
                 mPostedHide = true;
             }
         }

--- a/library/src/main/java/com/wang/avi/AVLoadingIndicatorView.java
+++ b/library/src/main/java/com/wang/avi/AVLoadingIndicatorView.java
@@ -206,8 +206,8 @@ public class AVLoadingIndicatorView extends View {
             // so put a delayed message in to hide it when its been
             // shown long enough.
             if (!mPostedHide) {
-                postDelayed(mDelayedHide, MIN_SHOW_TIME - diff);
                 mPostedHide = true;
+                postDelayed(mDelayedHide, MIN_SHOW_TIME - diff);
             }
         }
     }
@@ -218,8 +218,8 @@ public class AVLoadingIndicatorView extends View {
         mDismissed = false;
         removeCallbacks(mDelayedHide);
         if (!mPostedShow) {
-            postDelayed(mDelayedShow, MIN_DELAY);
             mPostedShow = true;
+            postDelayed(mDelayedShow, MIN_DELAY);
         }
     }
 


### PR DESCRIPTION
When` (MIN_SHOW_TIME - diff)` is less than or equals to 0, Runnable is called instantly. When this case occurred `mPostedHide` or/and `mPostedShow` were set to `true` and caused unexpected behavior.