### PR TITLE
fix using shared static default indicator issue

### DIFF
--- a/library/src/main/java/com/wang/avi/AVLoadingIndicatorView.java
+++ b/library/src/main/java/com/wang/avi/AVLoadingIndicatorView.java
@@ -21,7 +21,7 @@ public class AVLoadingIndicatorView extends View {
 
     private static final String TAG="AVLoadingIndicatorView";
 
-    private static final BallPulseIndicator DEFAULT_INDICATOR=new BallPulseIndicator();
+    private final BallPulseIndicator DEFAULT_INDICATOR=new BallPulseIndicator();
 
     private static final int MIN_SHOW_TIME = 500; // ms
     private static final int MIN_DELAY = 500; // ms


### PR DESCRIPTION
About the default indicator, it should't be static.
For some condition,  2 view would share one indicator, it would caused some strange issue